### PR TITLE
Automatically convert python dict to Dict

### DIFF
--- a/kadet/__init__.py
+++ b/kadet/__init__.py
@@ -9,6 +9,8 @@ class Dict(defaultdict):
         return self.__getitem__(name)
 
     def __setattr__(self, name, value):
+        if type(value) == dict:
+            value = Dict(from_dict=value)
         return self.__setitem__(name, value)
 
     def __repr__(self):

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 The Kadet Authors
+# SPDX-FileCopyrightText: 2021 The Kadet Authors <kapitan-admins@googlegroups.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"dict tests"
+
+import unittest
+from collections import defaultdict
+
+from kadet import Dict
+
+
+class DictTest(unittest.TestCase):
+    def test_dict_convert(self):
+        base = Dict()
+        base.foo = {"foo": "bar"}
+        self.assertIsInstance(base.foo, Dict)
+
+        base.bar = defaultdict(str)
+        self.assertFalse(isinstance(base.bar, Dict))


### PR DESCRIPTION
When setting a dict using the Dict attribute syntax, automatically convert it into a Dict.

This make code like this one valid:

```python
obj = kadet.BaseObj()

obj.root.labels = {"name": "name", "value": "value"}
obj.root.labels.other = "other" # fails without this change as labels would be a dict and not a Dict
```

This change is conservative and only convert the value if type(obj) == dict.
This is to make sure it does not convert a specialised dict (defaultdict, …) if the user chose to use one.