### PR TITLE
Allow set root to dict; add sha256()

### DIFF
--- a/kadet/__init__.py
+++ b/kadet/__init__.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+import hashlib
 import json
 
 import yaml
@@ -146,8 +147,12 @@ class BaseObj(object):
             else:
                 for k, v in obj.root.items():
                     obj.root[k] = self._dump(v)
+                if isinstance(obj.root, dict):
+                    # root is just a dict, return itself
+                    return obj.root
                 # BaseObj needs to return dump()
-                return obj.root.dump()
+                else:
+                    return obj.root.dump()
         elif isinstance(obj, list):
             obj = [self._dump(item) for item in obj]
             # list has no .dump, return itself
@@ -166,3 +171,7 @@ class BaseObj(object):
         returns object dict/list
         """
         return self._dump(self)
+
+    def sha256(self):
+        return hashlib.sha256(str(self.dump()).encode()).hexdigest()
+

--- a/kadet/__init__.py
+++ b/kadet/__init__.py
@@ -173,5 +173,7 @@ class BaseObj(object):
         return self._dump(self)
 
     def sha256(self):
+        """
+        returns sha256 hexdigest for self.root
+        """
         return hashlib.sha256(str(self.dump()).encode()).hexdigest()
-

--- a/tests/test_sha256.py
+++ b/tests/test_sha256.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 The Kadet Authors
+# SPDX-FileCopyrightText: 2021 The Kadet Authors <kapitan-admins@googlegroups.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"multidoc tests"
+
+import unittest
+from kadet import BaseObj
+
+
+class SHA256Test(unittest.TestCase):
+    def test_sha256_from_dict(self):
+        bobj = BaseObj.from_dict({'a':'b', 'c':'d'})
+        self.assertEqual(bobj.sha256(), '9f73f79e735571488426a6f7d7b009830fb306ee33d2952a8c6d5ffe6a86f921')
+
+    def test_sha256_set_root_dict(self):
+        bobj = BaseObj()
+        bobj.root = {'a':'b', 'c': 'd'}
+        self.assertEqual(bobj.sha256(), '9f73f79e735571488426a6f7d7b009830fb306ee33d2952a8c6d5ffe6a86f921')
+
+    def test_sha256_set_root_attrs(self):
+        bobj = BaseObj()
+        bobj.root.a = 'b'
+        bobj.root.c = 'd'
+        self.assertEqual(bobj.sha256(), '9f73f79e735571488426a6f7d7b009830fb306ee33d2952a8c6d5ffe6a86f921')
+
+    def test_sha256_set_root_list(self):
+        bobj = BaseObj()
+        bobj.root = [1,2,3,'a','b','c']
+        self.assertEqual(bobj.sha256(), '456a4d603ee5135d8966a00a2d49ebd94bbb9e6564c97918d3c5472dd017e2b2')

--- a/tests/test_sha256.py
+++ b/tests/test_sha256.py
@@ -13,21 +13,33 @@ from kadet import BaseObj
 
 class SHA256Test(unittest.TestCase):
     def test_sha256_from_dict(self):
-        bobj = BaseObj.from_dict({'a':'b', 'c':'d'})
-        self.assertEqual(bobj.sha256(), '9f73f79e735571488426a6f7d7b009830fb306ee33d2952a8c6d5ffe6a86f921')
+        bobj = BaseObj.from_dict({"a": "b", "c": "d"})
+        self.assertEqual(
+            bobj.sha256(),
+            "9f73f79e735571488426a6f7d7b009830fb306ee33d2952a8c6d5ffe6a86f921",
+        )
 
     def test_sha256_set_root_dict(self):
         bobj = BaseObj()
-        bobj.root = {'a':'b', 'c': 'd'}
-        self.assertEqual(bobj.sha256(), '9f73f79e735571488426a6f7d7b009830fb306ee33d2952a8c6d5ffe6a86f921')
+        bobj.root = {"a": "b", "c": "d"}
+        self.assertEqual(
+            bobj.sha256(),
+            "9f73f79e735571488426a6f7d7b009830fb306ee33d2952a8c6d5ffe6a86f921",
+        )
 
     def test_sha256_set_root_attrs(self):
         bobj = BaseObj()
-        bobj.root.a = 'b'
-        bobj.root.c = 'd'
-        self.assertEqual(bobj.sha256(), '9f73f79e735571488426a6f7d7b009830fb306ee33d2952a8c6d5ffe6a86f921')
+        bobj.root.a = "b"
+        bobj.root.c = "d"
+        self.assertEqual(
+            bobj.sha256(),
+            "9f73f79e735571488426a6f7d7b009830fb306ee33d2952a8c6d5ffe6a86f921",
+        )
 
     def test_sha256_set_root_list(self):
         bobj = BaseObj()
-        bobj.root = [1,2,3,'a','b','c']
-        self.assertEqual(bobj.sha256(), '456a4d603ee5135d8966a00a2d49ebd94bbb9e6564c97918d3c5472dd017e2b2')
+        bobj.root = [1, 2, 3, "a", "b", "c"]
+        self.assertEqual(
+            bobj.sha256(),
+            "456a4d603ee5135d8966a00a2d49ebd94bbb9e6564c97918d3c5472dd017e2b2",
+        )

--- a/tests/test_sha256.py
+++ b/tests/test_sha256.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"multidoc tests"
+"sha256 tests"
 
 import unittest
 from kadet import BaseObj


### PR DESCRIPTION
Adds support for setting root as dict

```python
b = kadet.BaseObj()
b.root = {'a':'b'}
```
is now the same as
```python
b = kadet.BaseObj()
b.root.a = 'b'
```

Also adds support for sha256() method

```python
b = kadet.BaseObj()
b.root.a = 'b'
print(b.sha256())
>> 786cd97a1aab145b408dc7298795aa73138af54acaf36df39d3c5267fbcebf71
```
